### PR TITLE
Move Inventory label

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -118,7 +118,7 @@ public:
         ItemPurchasePrice->setGeometry(QRect(650, 180, 191, 20));
         InventoryListLabel = new QLabel(centralwidget);
         InventoryListLabel->setObjectName(QString::fromUtf8("InventoryListLabel"));
-        InventoryListLabel->setGeometry(QRect(10, 50, 591, 20));
+        InventoryListLabel->setGeometry(QRect(10, 60, 591, 20));
         InventoryListLabel->setFont(font);
         InventoryListLabel->setAlignment(Qt::AlignCenter);
         ItemCategory = new QComboBox(centralwidget);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -181,7 +181,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>50</y>
+      <y>60</y>
       <width>591</width>
       <height>20</height>
      </rect>


### PR DESCRIPTION
Inventory label was too far away from the TableWidget. This closes #91 .